### PR TITLE
Fix supply choppers

### DIFF
--- a/Prefabs/Props/Military/SupplyBox/SupplyCrate/SupplyCrate_01/SupplyCrate_01_Vehicle.et
+++ b/Prefabs/Props/Military/SupplyBox/SupplyCrate/SupplyCrate_01/SupplyCrate_01_Vehicle.et
@@ -1,0 +1,8 @@
+GenericEntity : "{412CBCBED417FB62}Prefabs/Props/Military/SupplyBox/SupplyCrate/SupplyCrate_01/SupplyCrate_01_Base.et" {
+ ID "F0DBA538AC2A0552"
+ components {
+  RigidBody "{5872F0EB7DFB5A9D}" {
+   Enabled 0
+  }
+ }
+}

--- a/Prefabs/Props/Military/SupplyBox/SupplyCrate/SupplyCrate_01/SupplyCrate_01_Vehicle.et.meta
+++ b/Prefabs/Props/Military/SupplyBox/SupplyCrate/SupplyCrate_01/SupplyCrate_01_Vehicle.et.meta
@@ -1,5 +1,5 @@
 MetaFileClass {
- Name "{2FF27BCE04A24E51}Prefabs/Vehicles/Helicopters/Mi8MT/ORS_Mi8MT_Supplies.et"
+ Name "{11E588E215EBCF23}Prefabs/Props/Military/SupplyBox/SupplyCrate/SupplyCrate_01/SupplyCrate_01_Vehicle.et"
  Configurations {
   EntityTemplateResourceClass PC {
   }

--- a/Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/ORS_SupplyStack_01_V1_Vehicle.et
+++ b/Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/ORS_SupplyStack_01_V1_Vehicle.et
@@ -1,0 +1,8 @@
+GenericEntity : "{98A34AE10104A932}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/SupplyStack_01_V1_storage.et" {
+ ID "F0DBA538AC2A0552"
+ components {
+  RigidBody "{5872F0EB7DFB5A9D}" {
+   Enabled 0
+  }
+ }
+}

--- a/Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/ORS_SupplyStack_01_V1_Vehicle.et.meta
+++ b/Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/ORS_SupplyStack_01_V1_Vehicle.et.meta
@@ -1,5 +1,5 @@
 MetaFileClass {
- Name "{2FF27BCE04A24E51}Prefabs/Vehicles/Helicopters/Mi8MT/ORS_Mi8MT_Supplies.et"
+ Name "{98E824A028C63F8F}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/ORS_SupplyStack_01_V1_vehicle.et"
  Configurations {
   EntityTemplateResourceClass PC {
   }

--- a/Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et
+++ b/Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et
@@ -1,0 +1,8 @@
+GenericEntity : "{3260189525F39062}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_base.et" {
+ ID "F0DBA538AC2A0552"
+ components {
+  RigidBody "{5872F0EB7DFB5A9D}" {
+   Enabled 0
+  }
+ }
+}

--- a/Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et.meta
+++ b/Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et.meta
@@ -1,5 +1,5 @@
 MetaFileClass {
- Name "{2FF27BCE04A24E51}Prefabs/Vehicles/Helicopters/Mi8MT/ORS_Mi8MT_Supplies.et"
+ Name "{FE4A51A953C54DA0}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et"
  Configurations {
   EntityTemplateResourceClass PC {
   }

--- a/Prefabs/Vehicles/Helicopters/Mi8MT/ORS_Mi8MT_Supplies.et
+++ b/Prefabs/Vehicles/Helicopters/Mi8MT/ORS_Mi8MT_Supplies.et
@@ -17,18 +17,22 @@ Vehicle : "{DF5CCB7C0FF049F4}Prefabs/Vehicles/Helicopters/Mi8MT/Mi8MT.et" {
     RegisteringComponentSlotInfo SupplyStorage_01 {
      Offset -0.56 1.0177 -2.4617
      Angles 0 -90 0
+     DisablePhysicsInteraction 1
     }
     RegisteringComponentSlotInfo SupplyStorage_02 {
      Offset 0.53 1.0177 -2.4617
      Angles 0 90 0
+     DisablePhysicsInteraction 1
     }
     RegisteringComponentSlotInfo SupplyStorage_03 {
      Offset 0.53 1.0177 -1.3095
      Angles 0 90 0
+     DisablePhysicsInteraction 1
     }
     RegisteringComponentSlotInfo SupplyStorage_04 {
      Offset -0.56 1.0177 -1.3095
      Angles 0 -90 0
+     DisablePhysicsInteraction 1
     }
     RegisteringComponentSlotInfo SupplyStorage_05 {
      Offset 0.55 1.0177 -0.166

--- a/Prefabs/Vehicles/Helicopters/UH1H/ORS_UH1H_Supplies.et
+++ b/Prefabs/Vehicles/Helicopters/UH1H/ORS_UH1H_Supplies.et
@@ -20,12 +20,12 @@ Vehicle : "{70BAEEFC2D3FEE64}Prefabs/Vehicles/Helicopters/UH1H/UH1H.et" {
     RegisteringComponentSlotInfo SupplyStorage_01 {
      Offset 0.5563 0.8858 0.913
      Angles 0 -90 0
-     Prefab "{98A34AE10104A932}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/SupplyStack_01_V1_storage.et"
+     Prefab "{98E824A028C63F8F}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/ORS_SupplyStack_01_V1_Vehicle.et"
     }
     RegisteringComponentSlotInfo SupplyStorage_02 {
      Offset -0.5119 0.8858 0.913
      Angles 0 -90 0
-     Prefab "{98A34AE10104A932}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/SupplyStack_01_V1_storage.et"
+     Prefab "{98E824A028C63F8F}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/ORS_SupplyStack_01_V1_Vehicle.et"
     }
     RegisteringComponentSlotInfo SupplyStorage_03 {
      Offset 0.788 0.8781 -0.1313
@@ -88,6 +88,8 @@ Vehicle : "{70BAEEFC2D3FEE64}Prefabs/Vehicles/Helicopters/UH1H/UH1H.et" {
   ActionsManagerComponent "{C97BE5489221AE18}" {
    additionalActions {
     SCR_ResourceContainerVehicleLoadAction "{5E42966A989974E7}" {
+    }
+    SCR_ResourceContainerVehicleUnloadAction "{5E42966A9D4BFB90}" {
     }
     SCR_CampaignBuildingStartUserAction "{5EB8669114C65B44}" {
      ParentContextList {

--- a/Prefabs/Vehicles/Helicopters/UH1H/UH1H.et
+++ b/Prefabs/Vehicles/Helicopters/UH1H/UH1H.et
@@ -1,0 +1,15 @@
+Vehicle : "{D03C0F6044DB5208}Prefabs/Vehicles/Helicopters/UH1H/UH1H_base.et" {
+ ID "5DB688595BAB2FD7"
+ components {
+  ActionsManagerComponent "{C97BE5489221AE18}" {
+   additionalActions {
+    SCR_ResourceContainerVehicleLoadAction "{5E42966A989974E7}" {
+     Duration -1
+    }
+    SCR_ResourceContainerVehicleUnloadAction "{5E42966A9D4BFB90}" {
+     Duration -1
+    }
+   }
+  }
+ }
+}

--- a/Prefabs/Vehicles/Helicopters/UH1H/UH1H.et.meta
+++ b/Prefabs/Vehicles/Helicopters/UH1H/UH1H.et.meta
@@ -1,5 +1,5 @@
 MetaFileClass {
- Name "{2FF27BCE04A24E51}Prefabs/Vehicles/Helicopters/Mi8MT/ORS_Mi8MT_Supplies.et"
+ Name "{70BAEEFC2D3FEE64}Prefabs/Vehicles/Helicopters/UH1H/UH1H.et"
  Configurations {
   EntityTemplateResourceClass PC {
   }

--- a/scripts/Game/ORS/GameMode/ORS_GameMode.c
+++ b/scripts/Game/ORS/GameMode/ORS_GameMode.c
@@ -144,7 +144,10 @@ class ORS_GameMode : SCR_GameModeCampaign
 	{
 		// No more objective left => End game mode
 		if (m_iCurrentObjectiveAreaIdx >= m_aObjectiveAreas.Count())
-			EndGameMode(SCR_GameModeEndData.CreateSimple(EGameOverTypes.COMBATPATROL_VICTORY));
+		{
+			GetGame().GetCallqueue().CallLater(EndGameMode, 10000, false, SCR_GameModeEndData.CreateSimple(EGameOverTypes.COMBATPATROL_VICTORY));
+			return;
+		};
 		
 		m_pPreviousObjectiveArea = m_pCurrentObjectiveArea;
 		m_pCurrentObjectiveArea = m_aObjectiveAreas[m_iCurrentObjectiveAreaIdx];

--- a/worlds/ORS/Test/ORS_Test_Layers/extra.layer
+++ b/worlds/ORS/Test/ORS_Test_Layers/extra.layer
@@ -161,9 +161,220 @@ $grp Tree : "{2E810552D5E6CF78}Prefabs/Vegetation/Tree/t_betula_pendula_2sw.et" 
 }
 Vehicle ORS_Mi8MT_Supplies1 : "{2FF27BCE04A24E51}Prefabs/Vehicles/Helicopters/Mi8MT/ORS_Mi8MT_Supplies.et" {
  components {
+  SCR_BaseCompartmentManagerComponent "{20FB66C5DCB8DF72}" {
+   CompartmentSlots {
+    PilotCompartmentSlot PilotCompartment {
+     DoorInfoList {
+      CompartmentDoorInfo "{50B8D5DDA17EB35D}" {
+       EntryPositionInfo PointInfo "{50B8D5DD213DC00C}" {
+        PivotID "stepIn_pilot"
+        Offset 0 0 0
+        Angles 0 90 -4.796
+       }
+       ExitPositionInfo PointInfo "{5D4A962967F29EED}" {
+        PivotID "pilotl_idle"
+        Offset 0.0073 0.1619 -0.0001
+        Angles -4.796 0 0
+       }
+       GetInTeleport 0
+       GetOutTeleport 0
+      }
+     }
+    }
+    PilotCompartmentSlot Passenger_m01Cargo {
+     GetOutAction SCR_GetOutAction "{509D56667AFC4BD5}" {
+      "Sort Priority" 1
+     }
+     DoorInfoList {
+      CompartmentDoorInfo "{50B8D5DDA17EB35D}" {
+       EntryPositionInfo PointInfo "{50B8D5DD213DC00C}" {
+        PivotID "stepIn_pilot"
+        Offset 0 0 0
+        Angles 0 90 -4.796
+       }
+       ExitPositionInfo PointInfo "{5D5286FA390015EB}" {
+        PivotID "pilotl_idle"
+        Offset 0.0073 0.1619 -0.0001
+        Angles -4.796 0 0
+       }
+       GetInTeleport 0
+       SeatPositionAligning 0
+      }
+     }
+    }
+    CargoCompartmentSlot Passenger_m01 {
+     PassengerPositionInfo EntitySlotInfo "{699366C6D607AD06}" {
+      Offset 0 1.6 2.8
+      Angles -2.9742 0 0
+     }
+     SeatType 5
+     DoorInfoList {
+      CompartmentDoorInfo "{50B8D5DD7BC767A1}" {
+       ContextName "door_l01"
+       EntryPositionInfo PointInfo "{50B8D5DD78963937}" {
+        PivotID "stepIn_pilot"
+        Offset 0 0 0
+        Angles 0 90 -4.796
+       }
+       ExitPositionInfo PointInfo "{5A7CE769E7A9C4AA}" {
+        PivotID "pilotl_idle"
+        Offset 0.0073 0.1619 -0.0001
+        Angles -4.796 0 0
+       }
+       GetInTeleport 0
+       GetOutTeleport 0
+       SeatPositionAligning 0
+      }
+     }
+     UIInfo UIInfo "{50870A10CE897250}" {
+      Name "#AR-VehiclePosition_Navigator"
+     }
+     AccessibilitySettings CompartmentAccessibilityContext "{5A7CE769E7A9C4AF}" {
+      TraceOffset 0 0.2 0.75
+      TraceLength -0.8
+     }
+     ContextName "navigator"
+    }
+   }
+  }
   SCR_CampaignBuildingProviderComponent "{5EB86691AACA10EE}" {
    m_aBudgetsToEvaluate {
     2147483647 2147483647 2147483647
+   }
+  }
+  SCR_EditableVehicleComponent "{50DEB7C26B5EB312}" {
+   m_UIInfo SCR_EditableEntityUIInfo "{5298E609432D192D}" {
+    Name "#AR-Vehicle_Mi8MT_Name"
+    m_Image "{4FDC9EAA538B6EF8}UI/Textures/EditorPreviews/Vehicles/Helicopters/Mi8MT/Mi8MT.edds"
+    m_aAuthoredLabels +{
+    }
+   }
+  }
+  VehicleHelicopterSimulation "{51FAEE57F7DA270E}" {
+   Animation VehicleAnimation "{5D9CEE85AD0EE074}" {
+    VehicleParts {
+     VehiclePartAnimation "{5DF4B41DE714F310}" {
+      StartNode "eco_body_out"
+     }
+    }
+   }
+  }
+  SlotManagerComponent "{55BCE45E438E4CFF}" {
+   Slots {
+    RegisteringComponentSlotInfo door_rear {
+     PivotID "Scene_Root"
+     Prefab "{8952883E000BE636}Prefabs/Vehicles/Helicopters/Mi8MT/VehParts/Mi8MT_rear_door.et"
+    }
+    RegisteringComponentSlotInfo SeatsRear {
+     Enabled 0
+    }
+    RegisteringComponentSlotInfo SupplyStorage_01 {
+     Offset -0.56 1.0177 -2.4617
+     Angles 0 -90 0
+     DisablePhysicsInteraction 1
+    }
+    RegisteringComponentSlotInfo SupplyStorage_02 {
+     Offset 0.53 1.0177 -2.4617
+     Angles 0 90 0
+     DisablePhysicsInteraction 1
+    }
+    RegisteringComponentSlotInfo SupplyStorage_03 {
+     Offset 0.53 1.0177 -1.3095
+     Angles 0 90 0
+     DisablePhysicsInteraction 1
+    }
+    RegisteringComponentSlotInfo SupplyStorage_04 {
+     Offset -0.56 1.0177 -1.3095
+     Angles 0 -90 0
+     DisablePhysicsInteraction 1
+    }
+    RegisteringComponentSlotInfo SupplyStorage_05 {
+     Offset 0.55 1.0177 -0.166
+     Angles 0 90 0
+     Prefab "{FE4A51A953C54DA0}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et"
+     DisablePhysicsInteraction 1
+    }
+    RegisteringComponentSlotInfo SupplyStorage_06 {
+     Offset -0.5 1.0177 -0.1359
+     Angles 0 -90 0
+     Prefab "{FE4A51A953C54DA0}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et"
+     DisablePhysicsInteraction 1
+    }
+    RegisteringComponentSlotInfo SupplyStorage_07 {
+     Offset 0.566 1.0177 0.8904
+     Angles 0 -90 0
+     Prefab "{FE4A51A953C54DA0}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et"
+     DisablePhysicsInteraction 1
+    }
+    RegisteringComponentSlotInfo SupplyStorage_08 {
+     Offset -0.5 1.0177 0.8904
+     Angles 0 90 0
+     Prefab "{FE4A51A953C54DA0}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_Large_01/SupplyStack_Large_01_Vehicle.et"
+     DisablePhysicsInteraction 1
+    }
+   }
+  }
+  ActionsManagerComponent "{C97BE5489221AE18}" {
+   additionalActions {
+    SCR_ResourceEntityRefundAction "{5D5EC6128E6342C0}" {
+     ParentContextList +{
+     }
+    }
+    SCR_ResourceContainerVehicleLoadAction "{5DAD751A3D2FE182}" : "{A0E53319BFA4E848}Configs/Resources/Supplies/Actions/Supplies_Vehicle_Load.conf" {
+     ParentContextList {
+      "door_l01"
+     }
+    }
+    SCR_ResourceContainerVehicleUnloadAction "{5DAD751A3BF8492E}" : "{F10C4B3E2E87F15B}Configs/Resources/Supplies/Actions/Supplies_Vehicle_Unload.conf" {
+     ParentContextList {
+      "door_l01"
+     }
+    }
+    SCR_CampaignBuildingStartUserAction "{5EB8669114C65B44}" {
+     ParentContextList +{
+     }
+     UIInfo UIInfo "{5EB86691204A1630}" {
+      Name "#ORS-Action_StartBuildingFob_Name"
+     }
+     Duration 2
+     "Sort Priority" 23
+    }
+   }
+  }
+  SCR_ResourceComponent "{5E429668F7A8358A}" {
+   m_aContainers {
+    SCR_ResourceContainer "{5E42966B382452A6}" {
+     m_fResourceValueMax 0
+    }
+   }
+   m_aGenerators {
+    SCR_ResourceGenerator "{5E42966B6826B221}" : "{D0F12FFFB07D3955}Configs/Resources/Supplies/Generators/Generator_HelicopterLoad.conf" {
+    }
+    SCR_ResourceGenerator "{5E42966B68E9CC42}" : "{F02DC41374D82975}Configs/Resources/Supplies/Generators/Generator_HelicopterUnload.conf" {
+    }
+    SCR_ResourceGenerator "{5EB8B5AA66EF6DA0}" {
+     m_sDebugName "Generator - Engineer Helo"
+     m_eResourceRights ALL
+     m_fStorageRange 25
+     m_ContainerQueue SCR_ResourceGeneratorContainerQueue "{5EB8B5AB86BF1113}" {
+      m_StoragePolicies {
+       SCR_ResourceGeneratorStoragePolicy "{5EB8B5AB809D86BB}" {
+        m_StorageQueue SCR_ResourceGeneratorContainerStorageQueueExtended "{5EB8B5AB9587324A}" {
+        }
+        m_eStorageType CARGO_VEHICLE
+       }
+       SCR_ResourceGeneratorStoragePolicy "{5EB8B5AB8FB25BBC}" {
+        m_StorageQueue SCR_ResourceGeneratorContainerStorageQueueExtended "{5EB8B5AB9939A5FC}" {
+        }
+        m_eStorageType STORED
+       }
+       SCR_ResourceGeneratorStoragePolicy "{5EB8B5AB88E4C089}" {
+        m_StorageQueue SCR_ResourceGeneratorContainerStorageQueueExtended "{5EB8B5ABA5BD4E4D}" {
+        }
+       }
+      }
+     }
+    }
    }
   }
  }
@@ -299,11 +510,17 @@ GenericEntity : "{3BA9D94C4EE9B33B}Prefabs/Compositions/Slotted/CompositionBase.
 GenericEntity : "{4510C273B794F3A9}Prefabs/Compositions/Slotted/SlotFlatMedium/VehicleMaintenance_M_USSR_01.et" {
  coords 57.046 1 141.559
 }
+Vehicle ORS_UH1H_Supplies1 : "{4C2C8B0A1BEAC690}Prefabs/Vehicles/Helicopters/UH1H/ORS_UH1H_Supplies.et" {
+ coords 111.913 1 47.105
+}
 Tree : "{585B412BC51E59F3}Prefabs/Vegetation/Bush/b_juniperus_communis_1s.et" {
  coords 97.583 0 145.295
 }
 Vehicle Ural4320_engineer1 : "{6E9142CD2471741C}Prefabs/Vehicles/Wheeled/Ural4320/Ural4320_engineer.et" {
  coords 204.318 1 32.811
+}
+Vehicle UH1H1 : "{70BAEEFC2D3FEE64}Prefabs/Vehicles/Helicopters/UH1H/UH1H.et" {
+ coords 82.291 1 48.312
 }
 GenericEntity : "{847605BB95F1F066}PrefabsEditable/Auto/Compositions/Slotted/SlotFlatSmall/E_Headquarters_S_USSR_01.et" {
  coords 88.767 1 143.897
@@ -323,6 +540,9 @@ GenericEntity : "{894A1AFDCB71CD0D}Prefabs/Compositions/Misc/CustomEntities/Comp
 }
 Tree : "{9025E96A11516E7A}Prefabs/Vegetation/Bush/b_juniperus_communis_2w.et" {
  coords 98.923 0 136.791
+}
+GenericEntity : "{98E824A028C63F8F}Prefabs/Props/Military/SupplyBox/SupplyStack/SupplyStack_01/ORS_SupplyStack_01_V1_Vehicle.et" {
+ coords 35.826 1 116.761
 }
 Tree : "{A5DE58FC9FB6BA60}Prefabs/Vegetation/Bush/b_corylus_avellana_2.et" {
  coords 100.828 0 133.005


### PR DESCRIPTION
- Supply choppers got broken by a previous Reforger update. When loaded with supplies, the supplies interact with the chopper leading it to get bugged (and this despite explicitly disabling interactions for the supply slots).
- The current workaround is to completely disable interactions on vehicle supply boxes.